### PR TITLE
Force installation at compile time in chef >= 12

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -6,6 +6,9 @@
 # 
 
 chef_gem "chef-attribute-validator" do
+  # force installation at compile time in chef >= 12
+  compile_time true if defined? compile_time
+
   # attribute-validator's only dep is chef ~> 11.6
   # Having the omnibus chef try to upgrade itself as a gem 
   # is pretty much always a disaster; many native packages, may 


### PR DESCRIPTION
Fixed WARN on chef 12.

``````
WARN: chef_gem[chef-attribute-validator] chef_gem compile_time installation is deprecated
WARN: chef_gem[chef-attribute-validator] Please set `compile_time false` on the resource to use the new behavior.
WARN: chef_gem[chef-attribute-validator] or set `compile_time true` on the resource if compile_time behavior is required.```
``````
